### PR TITLE
Act accepts commands via env variables

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.16
 
 require (
 	github.com/fatih/color v1.10.0
+	github.com/mattn/go-shellwords v1.0.11
 	golang.org/x/text v0.3.5
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-shellwords v1.0.11 h1:vCoR9VPpsk/TZFW2JwK5I9S0xdrtUq2bph6/YjEPnaw=
+github.com/mattn/go-shellwords v1.0.11/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae h1:/WDfKMnPU+m5M4xB+6x4kaepxRw6jWvR5iDRdvjHgy8=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/common/storage.go
+++ b/internal/common/storage.go
@@ -50,8 +50,9 @@ type SearchResults struct {
 }
 
 type SearchResultsItem struct {
-	Key      string
-	Filename string
+	Key         string
+	Filename    string
+	ContentType string
 }
 
 func NewStorage(filename string) Storage {

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -129,8 +129,11 @@ func (c *SearchCommand) Run(args []string, config Config) {
 				path := MakePath(config.Zotero, attach.Key, attach.Filename)
 				ns := fmt.Sprintf("%3d)", i)
 				fmt.Printf("%s %s\n", selColor.Sprint(ns), attachColor.Sprint(path))
-				res.Items = append(res.Items,
-					SearchResultsItem{Key: attach.Key, Filename: attach.Filename})
+				res.Items = append(res.Items, SearchResultsItem{
+					Key:         attach.Key,
+					Filename:    attach.Filename,
+					ContentType: attach.ContentType,
+				})
 				i++
 			}
 		}

--- a/test/act.bats
+++ b/test/act.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats -t
+
+load helpers
+
+@test "Act forget empty" {
+    cp_storage empty
+    run_zotools act -forget
+    [ "$status" -eq 0 ]
+    local pat='"Search":[[:space:]]*null'
+    [[ "$(storage_contents)" =~ $pat ]]
+}
+
+@test "Act forget non-empty" {
+    cp_storage single_result
+    run_zotools act -forget
+    [ "$status" -eq 0 ]
+    local pat='"Search":[[:space:]]*null'
+    [[ "$(storage_contents)" =~ $pat ]]
+}
+
+@test "Act no search" {
+    cp_storage empty
+    run_zotools act echo
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "No stored search" ]]
+}
+
+@test "Act index out of range" {
+    cp_storage single_result
+    run_zotools act -i=42 echo
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Index 42 is invalid" ]]
+}
+
+@test "Act unknown MIME" {
+    cp_storage mime_unknown
+    run_zotools act
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Unknown extension" ]]
+}
+
+@test "Act broken MIME" {
+    cp_storage mime_broken
+    run_zotools act
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Could not parse MIME type" ]]
+}
+
+@test "Act known MIME action" {
+    cp_storage single_result
+    ZOTOOLS_PDF=echo run_zotools act
+    [ "$status" -eq 0 ]
+    [[ "${lines[1]}" =~ "5D9UT6I4" ]]
+}
+
+@test "Act known MIME action broken command" {
+    cp_storage single_result
+    ZOTOOLS_PDF="echo -n 'Hello" run_zotools act
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Failed to parse ZOTOOLS_PDF" ]]
+}
+
+@test "Act unknown MIME action" {
+    cp_storage single_result
+    run_zotools act
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Command not found for MIME type" ]]
+}
+
+@test "Act command run error" {
+    cp_storage single_result
+    run_zotools act hopefullythisprogramisnotavailableanywhereweruntests
+    [ "$status" -eq 1 ]
+    [[ "${lines[0]}" =~ "5D9UT6I4" ]]
+    [[ "$output" =~ "Failed to run action" ]]
+}

--- a/test/assets/config.json
+++ b/test/assets/config.json
@@ -1,1 +1,1 @@
-{"key": "", "zotero": "", "storage": "test/assets/storage.json"}
+{"key": "", "zotero": "", "storage": "test/assets/storage.tmp.json"}

--- a/test/assets/storage_empty.json
+++ b/test/assets/storage_empty.json
@@ -1,0 +1,7 @@
+{
+  "Lib": {
+    "Version": 1,
+    "Items": []
+  },
+  "Search": null
+}

--- a/test/assets/storage_search_mime_broken.json
+++ b/test/assets/storage_search_mime_broken.json
@@ -1,0 +1,42 @@
+{
+  "Lib": {
+    "Version": 1,
+    "Items": [
+      {
+        "Key": "VV7CF8HT",
+        "Version": 447,
+        "Title": "FuzzerGym: A Competitive Framework for Fuzzing and Learning",
+        "Abstract": "Fuzzing is a commonly used technique designed to test software by automatically crafting program inputs. Currently, the most successful fuzzing algorithms emphasize simple, low-overhead strategies with the ability to efficiently monitor program state during execution. Through compile-time instrumentation, these approaches have access to numerous aspects of program state including coverage, data flow, and heterogeneous fault detection and classification. However, existing approaches utilize blind random mutation strategies when generating test inputs. We present a different approach that uses this state information to optimize mutation operators using reinforcement learning (RL). By integrating OpenAI Gym with libFuzzer we are able to simultaneously leverage advancements in reinforcement learning as well as fuzzing to achieve deeper coverage across several varied benchmarks. Our technique connects the rich, efficient program monitors provided by LLVM Santizers with a deep neural net to learn mutation selection strategies directly from the input data. The cross-language, asynchronous architecture we developed enables us to apply any OpenAI Gym compatible deep reinforcement learning algorithm to any fuzzing problem with minimal slowdown.",
+        "ItemType": "",
+        "Creators": [
+          {
+            "firstName": "William",
+            "lastName": "Drozd"
+          },
+          {
+            "firstName": "Michael D.",
+            "lastName": "Wagner"
+          }
+        ],
+        "Attachments": [
+          {
+            "Key": "5D9UT6I4",
+            "Version": 448,
+            "ContentType": "application/pdf",
+            "Filename": "Drozd and Wagner - 2018 - FuzzerGym A Competitive Framework for Fuzzing and.pdf"
+          }
+        ]
+      }
+    ]
+  },
+  "Search": {
+    "Term": "FuzzerGym",
+    "Items": [
+      {
+        "Key": "5D9UT6I4",
+        "Filename": "Drozd and Wagner - 2018 - FuzzerGym A Competitive Framework for Fuzzing and.pdf",
+        "ContentType": "qwertyuerr/"
+      }
+    ]
+  }
+}

--- a/test/assets/storage_search_mime_unknown.json
+++ b/test/assets/storage_search_mime_unknown.json
@@ -1,0 +1,42 @@
+{
+  "Lib": {
+    "Version": 1,
+    "Items": [
+      {
+        "Key": "VV7CF8HT",
+        "Version": 447,
+        "Title": "FuzzerGym: A Competitive Framework for Fuzzing and Learning",
+        "Abstract": "Fuzzing is a commonly used technique designed to test software by automatically crafting program inputs. Currently, the most successful fuzzing algorithms emphasize simple, low-overhead strategies with the ability to efficiently monitor program state during execution. Through compile-time instrumentation, these approaches have access to numerous aspects of program state including coverage, data flow, and heterogeneous fault detection and classification. However, existing approaches utilize blind random mutation strategies when generating test inputs. We present a different approach that uses this state information to optimize mutation operators using reinforcement learning (RL). By integrating OpenAI Gym with libFuzzer we are able to simultaneously leverage advancements in reinforcement learning as well as fuzzing to achieve deeper coverage across several varied benchmarks. Our technique connects the rich, efficient program monitors provided by LLVM Santizers with a deep neural net to learn mutation selection strategies directly from the input data. The cross-language, asynchronous architecture we developed enables us to apply any OpenAI Gym compatible deep reinforcement learning algorithm to any fuzzing problem with minimal slowdown.",
+        "ItemType": "",
+        "Creators": [
+          {
+            "firstName": "William",
+            "lastName": "Drozd"
+          },
+          {
+            "firstName": "Michael D.",
+            "lastName": "Wagner"
+          }
+        ],
+        "Attachments": [
+          {
+            "Key": "5D9UT6I4",
+            "Version": 448,
+            "ContentType": "application/pdf",
+            "Filename": "Drozd and Wagner - 2018 - FuzzerGym A Competitive Framework for Fuzzing and.pdf"
+          }
+        ]
+      }
+    ]
+  },
+  "Search": {
+    "Term": "FuzzerGym",
+    "Items": [
+      {
+        "Key": "5D9UT6I4",
+        "Filename": "Drozd and Wagner - 2018 - FuzzerGym A Competitive Framework for Fuzzing and.pdf",
+        "ContentType": "application/qwertyuerr"
+      }
+    ]
+  }
+}

--- a/test/assets/storage_search_single_result.json
+++ b/test/assets/storage_search_single_result.json
@@ -1,0 +1,42 @@
+{
+  "Lib": {
+    "Version": 1,
+    "Items": [
+      {
+        "Key": "VV7CF8HT",
+        "Version": 447,
+        "Title": "FuzzerGym: A Competitive Framework for Fuzzing and Learning",
+        "Abstract": "Fuzzing is a commonly used technique designed to test software by automatically crafting program inputs. Currently, the most successful fuzzing algorithms emphasize simple, low-overhead strategies with the ability to efficiently monitor program state during execution. Through compile-time instrumentation, these approaches have access to numerous aspects of program state including coverage, data flow, and heterogeneous fault detection and classification. However, existing approaches utilize blind random mutation strategies when generating test inputs. We present a different approach that uses this state information to optimize mutation operators using reinforcement learning (RL). By integrating OpenAI Gym with libFuzzer we are able to simultaneously leverage advancements in reinforcement learning as well as fuzzing to achieve deeper coverage across several varied benchmarks. Our technique connects the rich, efficient program monitors provided by LLVM Santizers with a deep neural net to learn mutation selection strategies directly from the input data. The cross-language, asynchronous architecture we developed enables us to apply any OpenAI Gym compatible deep reinforcement learning algorithm to any fuzzing problem with minimal slowdown.",
+        "ItemType": "",
+        "Creators": [
+          {
+            "firstName": "William",
+            "lastName": "Drozd"
+          },
+          {
+            "firstName": "Michael D.",
+            "lastName": "Wagner"
+          }
+        ],
+        "Attachments": [
+          {
+            "Key": "5D9UT6I4",
+            "Version": 448,
+            "ContentType": "application/pdf",
+            "Filename": "Drozd and Wagner - 2018 - FuzzerGym A Competitive Framework for Fuzzing and.pdf"
+          }
+        ]
+      }
+    ]
+  },
+  "Search": {
+    "Term": "FuzzerGym",
+    "Items": [
+      {
+        "Key": "5D9UT6I4",
+        "Filename": "Drozd and Wagner - 2018 - FuzzerGym A Competitive Framework for Fuzzing and.pdf",
+        "ContentType": "application/pdf"
+      }
+    ]
+  }
+}

--- a/test/generic.bats
+++ b/test/generic.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats -t
+
+load helpers
+
+@test "Version" {
+    run_zotools -V
+    [ "$status" -eq 0 ]
+}
+
+@test "No command" {
+    run_zotools
+    [ "$status" -eq 1 ]
+}
+
+@test "Unknown command" {
+    run_zotools unknowncommand
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Command 'unknowncommand' not recognized" ]]
+}
+
+@test "Help command" {
+    run_zotools help
+    [ "$status" -eq 0 ]
+    local pat='Usage: .+ \[OPTIONS\] command'
+    [[ "$output" =~ $pat ]]
+}
+
+@test "Search-act integration" {
+    run_zotools search aflnet
+    [ "$status" -eq 0 ]
+    [[ "${lines[@]}" =~ "XZU8ER4Q" ]]
+
+    run_zotools act echo
+    [ "$status" -eq 0 ]
+    [[ "${lines[1]}" =~ "XZU8ER4Q" ]]
+}

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -1,5 +1,11 @@
 COVERAGE_PATH=${COVERAGE_PATH:-$(pwd)/.coverage}
 ZOTOOLS_BIN=${ZOTOOLS_BIN:-$(pwd)/build/zotools}
+STORAGE_SRC="$(pwd)/test/assets/storage.json"
+STORAGE="$(pwd)/test/assets/storage.tmp.json"
+STORAGE_MIME_UNKNOWN="$(pwd)/test/assets/storage_search_mime_unknown.json"
+STORAGE_MIME_BROKEN="$(pwd)/test/assets/storage_search_mime_broken.json"
+STORAGE_SINGLE_RES="$(pwd)/test/assets/storage_search_single_result.json"
+STORAGE_EMPTY="$(pwd)/test/assets/storage_empty.json"
 
 random_string() {
     local length=${1:-10}
@@ -20,4 +26,33 @@ run_zotools() {
     if [ "$status" -ne 0 ]; then
         echo "$output"
     fi
+}
+
+setup() {
+    cp "$STORAGE_SRC" "$STORAGE"
+}
+
+teardown() {
+    rm "$STORAGE"
+}
+
+cp_storage() {
+    case "$1" in
+        mime_unknown)
+            cp "$STORAGE_MIME_UNKNOWN" "$STORAGE"
+            ;;
+        mime_broken)
+            cp "$STORAGE_MIME_BROKEN" "$STORAGE"
+            ;;
+        single_result)
+            cp "$STORAGE_SINGLE_RES" "$STORAGE"
+            ;;
+        empty)
+            cp "$STORAGE_EMPTY" "$STORAGE"
+            ;;
+    esac
+}
+
+storage_contents() {
+    cat "$STORAGE"
 }

--- a/test/search.bats
+++ b/test/search.bats
@@ -2,29 +2,6 @@
 
 load helpers
 
-@test "Version" {
-    run_zotools -V
-    [ "$status" -eq 0 ]
-}
-
-@test "No command" {
-    run_zotools
-    [ "$status" -eq 1 ]
-}
-
-@test "Unknown command" {
-    run_zotools unknowncommand
-    [ "$status" -eq 1 ]
-    [[ "$output" =~ "Command 'unknowncommand' not recognized" ]]
-}
-
-@test "Help command" {
-    run_zotools help
-    [ "$status" -eq 0 ]
-    local pat='Usage: .+ \[OPTIONS\] command'
-    [[ "$output" =~ $pat ]]
-}
-
 @test "Simple search" {
     run_zotools search learn
     [ "$status" -eq 0 ]
@@ -69,29 +46,4 @@ load helpers
     run_zotools search -j=1337 aflnet
     [ "$status" -eq 1 ]
     [[ ! "$output" =~ "AFLNET" ]]
-}
-
-@test "Simple act" {
-    run_zotools search aflnet
-    [ "$status" -eq 0 ]
-    [[ "${lines[@]}" =~ "XZU8ER4Q" ]]
-
-    run_zotools act echo
-    [ "$status" -eq 0 ]
-    [[ "${lines[1]}" =~ "XZU8ER4Q" ]]
-}
-
-@test "Act no command" {
-    run_zotools act
-    [ "$status" -eq 1 ]
-}
-
-@test "Act index out of range" {
-    run_zotools search aflnet
-    [ "$status" -eq 0 ]
-    [[ "${lines[@]}" =~ "XZU8ER4Q" ]]
-
-    run_zotools act -i=42 echo
-    [ "$status" -eq 1 ]
-    [[ "$output" =~ "42" ]]
 }


### PR DESCRIPTION
If no command is given as argument, it will use the content-type obtained from Zotero to search for an environment variable of the form `ZOTOOLS_EXT` where `EXT` is replaced with an extension associated with the MIME type for the selected item. This environment variable is parsed as a shell command (i.e. string quoting, etc.).